### PR TITLE
Update composer dependencies to support Laravel v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^11.0",
         "league/flysystem": "^3.0",
         "maennchen/zipstream-php": ">=2.0",
         "ctf0/package-changelog": "*"


### PR DESCRIPTION
The composer dependencies are modified to support Laravel v11.